### PR TITLE
Annotate fusions

### DIFF
--- a/code/01-annotate-fusions.R
+++ b/code/01-annotate-fusions.R
@@ -13,6 +13,7 @@ output_dir <- file.path(data_dir, "merged_files")
 bioMartDataPfam <- readRDS(system.file("extdata", "pfamDataBioMart.RDS", package = "annoFuseData"))
 
 # pull hope cohort fusion files
+# this file is generated in 00-create_merged_files.R
 hope_cohort_fusions <- readRDS(file.path(output_dir, "fusions_merged.rds"))
 hope_cohort_fusions <- hope_cohort_fusions %>%
   dplyr::rename("Sample" = "Kids_First_Biospecimen_ID") # to keep column names consistent with OpenPedCan repo


### PR DESCRIPTION
I used `annoFuse::get_Pfam_domain` and `annoFuse::called_by_n_callers` function to create the final `Hope-fusion-putative-oncogenic.rds`. I have formatted the data to have the columns match exactly with those in OpenPedCan's `fusion-putative-oncogenic.tsv` file.

Fixes: #22 

Note: the branch name says filter-fusions but I am just annotating, not filtering any fusions.
