### PR TITLE
fwrite tab delimited

### DIFF
--- a/analyses/merge-files/01-create_merged_files.R
+++ b/analyses/merge-files/01-create_merged_files.R
@@ -91,7 +91,7 @@ hope_cohort_mutations <- list.files(path = file.path(input_dir, "consenus_maf"),
 hope_cohort_mutations <- lapply(hope_cohort_mutations, FUN = function(x) readr::read_tsv(x, skip = 1))
 hope_cohort_mutations <- plyr::rbind.fill(hope_cohort_mutations)
 length(unique(hope_cohort_mutations$Tumor_Sample_Barcode))
-data.table::fwrite(x = hope_cohort_mutations, file = file.path(output_dir, "Hope-snv-consensus-plus-hotspots.maf.tsv.gz"))
+data.table::fwrite(x = hope_cohort_mutations, file = file.path(output_dir, "Hope-snv-consensus-plus-hotspots.maf.tsv.gz"), sep = "\t")
 
 # manifest for cnv files
 cnv_manifest <- read_tsv(file.path(input_dir, "manifest", "manifest_20230830_151211_cnv.tsv"))

--- a/analyses/merge-files/02-create_merged_files_tumor_only.R
+++ b/analyses/merge-files/02-create_merged_files_tumor_only.R
@@ -20,7 +20,7 @@ hope_cohort_mutations <- hope_cohort_mutations %>%
   filter(t_alt_count != 0, 
          t_depth > 5)
 length(unique(hope_cohort_mutations$Tumor_Sample_Barcode))
-data.table::fwrite(x = hope_cohort_mutations, file = file.path(output_dir, "Hope-tumor-only-snv-mutect2.maf.tsv.gz"))
+data.table::fwrite(x = hope_cohort_mutations, file = file.path(output_dir, "Hope-tumor-only-snv-mutect2.maf.tsv.gz"), sep = "\t")
 
 # manifest for cnv files
 cnv_manifest <- read_tsv(file.path(input_dir, "manifest_tumor_only", "manifest_20230830_152155_cnv.tsv"))


### PR DESCRIPTION
Add `sep = "\t"` to `data.table::fwrite` for writing compressed tsv files. 

Fixes: https://github.com/d3b-center/D3b-codes/issues/103