### PR TITLE
Update merge files code (2/11)

### DIFF
--- a/analyses/merge-files/01-create_merged_files.R
+++ b/analyses/merge-files/01-create_merged_files.R
@@ -51,6 +51,7 @@ tpm <- tpm %>%
   dplyr::select(rna_hist$file_name)
 identical(rna_hist$file_name, colnames(tpm))
 colnames(tpm) <- rna_hist$Kids_First_Biospecimen_ID
+print(dim(tpm))
 tpm %>%
   rownames_to_column("gene_id") %>%
   saveRDS(file = file.path(output_dir, "Hope-gene-expression-rsem-tpm.rds"))
@@ -82,6 +83,7 @@ counts <- counts %>%
   dplyr::select(rna_hist$file_name)
 identical(rna_hist$file_name, colnames(counts))
 colnames(counts) <- rna_hist$Kids_First_Biospecimen_ID
+print(dim(counts))
 counts %>%
   rownames_to_column("gene_id") %>%
   saveRDS(file = file.path(output_dir, "Hope-gene-counts-rsem-expected_count.rds"))
@@ -99,7 +101,7 @@ hope_cohort_mutations <- lapply(hope_cohort_mutations, FUN = function(x) readr::
 hope_cohort_mutations <- plyr::rbind.fill(hope_cohort_mutations)
 hope_cohort_mutations <- hope_cohort_mutations %>%
   filter(Tumor_Sample_Barcode %in% hist_df$Kids_First_Biospecimen_ID)
-length(unique(hope_cohort_mutations$Tumor_Sample_Barcode))
+print(length(unique(hope_cohort_mutations$Tumor_Sample_Barcode)))
 data.table::fwrite(x = hope_cohort_mutations, file = file.path(output_dir, "Hope-snv-consensus-plus-hotspots.maf.tsv.gz"), sep = "\t")
 
 # manifest for cnv files
@@ -131,7 +133,7 @@ merge_cnv <- function(nm){
     unique()
 
   # modify
-  output$status <- stringr::str_to_title(output$status)
+  # output$status <- stringr::str_to_title(output$status)
   if(nrow(output) > 1){
     output$Kids_First_Biospecimen_ID <- sample_name
     return(output)
@@ -139,7 +141,7 @@ merge_cnv <- function(nm){
 }
 
 # get coordinates of genes from gencode v39
-gencode_gtf <- rtracklayer::import(con = "data/gencode.v39.primary_assembly.annotation.gtf.gz")
+gencode_gtf <- rtracklayer::import(con = file.path(root_dir, "data", "gencode.v39.primary_assembly.annotation.gtf.gz"))
 gencode_gtf <- as.data.frame(gencode_gtf)
 gencode_gtf <- gencode_gtf %>%
   dplyr::select(seqnames, start, end, gene_name) %>%

--- a/analyses/merge-files/02-create_merged_files_tumor_only.R
+++ b/analyses/merge-files/02-create_merged_files_tumor_only.R
@@ -56,7 +56,7 @@ merge_cnv <- function(nm){
     unique()
   
   # modify
-  output$status <- stringr::str_to_title(output$status)
+  # output$status <- stringr::str_to_title(output$status)
   if(nrow(output) > 1){
     output$Kids_First_Biospecimen_ID <- sample_name
     return(output)
@@ -64,7 +64,7 @@ merge_cnv <- function(nm){
 }
 
 # get coordinates of genes from gencode v39
-gencode_gtf <- rtracklayer::import(con = "data/gencode.v39.primary_assembly.annotation.gtf.gz")
+gencode_gtf <- rtracklayer::import(con = file.path(root_dir, "data", "gencode.v39.primary_assembly.annotation.gtf.gz"))
 gencode_gtf <- as.data.frame(gencode_gtf)
 gencode_gtf <- gencode_gtf %>%
   dplyr::select(seqnames, start, end, gene_name) %>%

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,7 +1,7 @@
 # Release note
 
 ## Current release (V3)
-- release data: 2024-08-16
+- release date: 2024-08-16
 - Overview:
   - Sequence sample:
     - 87 RNA-seq
@@ -15,7 +15,7 @@
 
 
 ## Current release (V2)
-- release data: 2023-11-21
+- release date: 2023-11-21
 - Overview:
   - Sequence sample:
     - 184 RNA-seq

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,19 @@
 # Release note
 
+## Current release (V3)
+- release data: 2024-08-16
+- Overview:
+  - Sequence sample:
+    - 87 RNA-seq
+    - 157 WGS
+    - 80 DNA methylation
+    - 27 snRNA-Seq
+    - 91 Phospho-Proteomics
+    - 91 Whole Cell Proteomics
+- Updates: 
+  - Genomics data from two samples (`7316-1106` and `7316-3000`) were added back in.
+
+
 ## Current release (V2)
 - release data: 2023-11-21
 - Overview:

--- a/download-data.sh
+++ b/download-data.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 # Set URL and release
 URL=${HOPE_URL:-https://s3.amazonaws.com/d3b-openaccess-us-east-1-prd-pbta/hope-aya}
-RELEASE=${VERSION:-v2}
-PREVIOUS=${VERSION:-v1}
+RELEASE=${VERSION:-v3}
+PREVIOUS=${VERSION:-v2}
 
 # Set the working directory to the directory of this file
 cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
Quick update: 

I first updated the histologies base file to add the two missing samples and soft-linked it under `data/`. Then, I re-ran the modified scripts (i.e. remove title case from CNV file, update path to gencode v39) to generate the merged files for v3 release. 

In addition to the updated histologies file, I have updated and uploaded to s3 (v3 folder) the following merged files:

```
results
├── Hope-cnv-controlfreec-tumor-only.rds
├── Hope-cnv-controlfreec.rds
├── Hope-fusion-putative-oncogenic.rds
├── Hope-gene-counts-rsem-expected_count-collapsed.rds
├── Hope-gene-counts-rsem-expected_count.rds
├── Hope-gene-expression-rsem-tpm-collapsed.rds
├── Hope-gene-expression-rsem-tpm.rds
├── Hope-snv-consensus-plus-hotspots.maf.tsv.gz
├── Hope-tumor-only-snv-mutect2.maf.tsv.gz
└── md5sum.txt
```

For the `md5sum.txt`, I have only updated the md5sums for the above files generated by my merge script).

Here is the comparison of sample size between v2 and the above merged files (i.e. v3) - each file's sample size has increased by 2:

```
> # Counts
> counts_file = readRDS("data/Hope-gene-counts-rsem-expected_count-collapsed.rds")
> length(colnames(counts_file))
[1] 85

> counts_file = readRDS("analyses/merge-files/results/Hope-gene-counts-rsem-expected_count-collapsed.rds")
> length(colnames(counts_file))
[1] 87

> # TPM
> tpm_file = readRDS("data/Hope-gene-expression-rsem-tpm-collapsed.rds")
> length(colnames(tpm_file))
[1] 85

> tpm_file = readRDS("analyses/merge-files/results/Hope-gene-expression-rsem-tpm-collapsed.rds")
> length(colnames(tpm_file))
[1] 87

> # SNV
> snv_file <- data.table::fread("data/Hope-snv-consensus-plus-hotspots.maf.tsv.gz")
> length(unique(snv_file$Tumor_Sample_Barcode))
[1] 71

> snv_file <- data.table::fread("analyses/merge-files/results/Hope-snv-consensus-plus-hotspots.maf.tsv.gz")
> length(unique(snv_file$Tumor_Sample_Barcode))
[1] 73

> # SNV tumor-only 
> snv_tumor_only_file <- data.table::fread("data/Hope-tumor-only-snv-mutect2.maf.tsv.gz")
> length(unique(snv_tumor_only_file$Tumor_Sample_Barcode))
[1] 88

> snv_tumor_only_file <- data.table::fread("analyses/merge-files/results/Hope-tumor-only-snv-mutect2.maf.tsv.gz")
> length(unique(snv_tumor_only_file$Tumor_Sample_Barcode))
[1] 90

> # CNV
> cnv_file <- readRDS("data/Hope-cnv-controlfreec.rds")
> length(unique(cnv_file$Kids_First_Biospecimen_ID))
[1] 71

> cnv_file <- readRDS("analyses/merge-files/results/Hope-cnv-controlfreec.rds")
> length(unique(cnv_file$Kids_First_Biospecimen_ID))
[1] 73

> # CNV tumor-only
> cnv_tumor_only_file <- readRDS("data/Hope-cnv-controlfreec-tumor-only.rds")
> length(unique(cnv_tumor_only_file$Kids_First_Biospecimen_ID))
[1] 88

> cnv_tumor_only_file <- readRDS("analyses/merge-files/results/Hope-cnv-controlfreec-tumor-only.rds")
> length(unique(cnv_tumor_only_file$Kids_First_Biospecimen_ID))
[1] 90

> # Fusions
> fusion_file <- readRDS("data/Hope-fusion-putative-oncogenic.rds")
> length(unique(fusion_file$Sample))
[1] 85

> fusion_file <- readRDS("analyses/merge-files/results/Hope-fusion-putative-oncogenic.rds")
> length(unique(fusion_file$Sample))
[1] 87
```